### PR TITLE
README Fix and Adding Content-Type Method

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This Go package provides a wrapper to interact with the [Aircall API](http://dev
 ## How to install
 
 ```
-go get -u github.com/joaoh82/aircall
+go get -u github.com/leoht/aircall
 ```
 
 ## Quick start
@@ -15,7 +15,7 @@ package main
 
 import (
     "fmt"
-    "github.com/joaoh82/aircall"
+    "github.com/leoht/aircall"
 )
 
 func main() {

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This Go package provides a wrapper to interact with the [Aircall API](http://dev
 ## How to install
 
 ```
-go get -u github.com/leoht/aircall
+go get -u github.com/joaoh82/aircall
 ```
 
 ## Quick start
@@ -15,7 +15,7 @@ package main
 
 import (
     "fmt"
-    "github.com/leoht/aircall"
+    "github.com/joaoh82/aircall"
 )
 
 func main() {
@@ -46,7 +46,7 @@ func main() {
         fmt.Println("User", u.ID, u.Name)
 
         // Get specific user
-        userRes, err := client.User(user.ID)
+        userRes, err := client.User(u.ID)
     }
     
     // Get numbers

--- a/client.go
+++ b/client.go
@@ -61,7 +61,7 @@ func (client *Client) Request(method string, path string, params map[string]stri
 		return nil, err
 	}
 
-	rew.Header.Add("Content-Type"), "application/json")
+	rew.Header.Add("Content-Type", "application/json")
 	req.Header.Add("Authorization", "Basic "+basicAuthHeader(client.AppID, client.AppToken))
 
 	c := &http.Client{}

--- a/client.go
+++ b/client.go
@@ -61,6 +61,7 @@ func (client *Client) Request(method string, path string, params map[string]stri
 		return nil, err
 	}
 
+	rew.Header.Add("Content-Type"), "application/json")
 	req.Header.Add("Authorization", "Basic "+basicAuthHeader(client.AppID, client.AppToken))
 
 	c := &http.Client{}

--- a/client.go
+++ b/client.go
@@ -61,7 +61,7 @@ func (client *Client) Request(method string, path string, params map[string]stri
 		return nil, err
 	}
 
-	rew.Header.Add("Content-Type", "application/json")
+	req.Header.Add("Content-Type", "application/json")
 	req.Header.Add("Authorization", "Basic "+basicAuthHeader(client.AppID, client.AppToken))
 
 	c := &http.Client{}


### PR DESCRIPTION
By not passing the Content-Type as application/json, the Aircall API ignores the update but does not return any error also, just does not change anything. 

This can be verified with REST tools like Advanced REST Client.

Anyway, you did a great job creating the wrapper, but I forked and added the Content-Type to it and thought it would be a good addition to main repo.

Cheers,

Joao